### PR TITLE
NLT behavior and mount detection fixes (#35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Ansinimble is beta software and might introduce breaking changes between version
 ## Role Variables
 The importance of variables depends on what objects are being managed.
 
-These are the offical defaults that are accompanied for each task or used as an example data structure.
+These are the offical defaults that are accompanied for each task or used as an example data structure. Some variables makes sense per host, per ansible host or grouped. Explore each task to learn more.
 ```
 ---
 # These are required.
@@ -253,9 +253,9 @@ nimble_host_protocol: iscsi
 # Set to True to disable any NLT interaction
 nimble_linux_toolkit_ignore: False
 
-# Set to True to disable connecting NLT to array
+# Set to False to enable connecting NLT to array
 # Not honored if nimble_linux_toolkit_ignore is True
-nimble_linux_toolkit_nogroup: False
+nimble_linux_toolkit_nogroup: True
 
 # Default initiator options
 nimble_initiator_group_options_default:
@@ -653,26 +653,8 @@ Example:
 ```
 ok: [smokey] => {
     "nimble_host_facts": {
-        "docker": {
-            "options": {
-                "docker.volume.dir": "/opt/nimble/", 
-                "nos.clone.snapshot.prefix": "BaseFor", 
-                "nos.default.perfpolicy.name": "DockerDefault", 
-                "nos.volume.destroy.when.removed": "false", 
-                "nos.volume.name.prefix": "", 
-                "nos.volume.name.suffix": ".docker"
-            }, 
-            "status": "DISABLED"
-        }, 
-        "groups": {
-            "main": {
-                "group_ip": "192.168.59.64", 
-                "protocol": "iscsi", 
-                "status": "enabled", 
-                "user": "admin"
-            }
-        }, 
-        "iqn": "iqn.1994-05.com.redhat:44be4d73789"
+        "iqn": "iqn.1994-05.com.redhat:44be4d73789",
+        "wwpns": []
     }
 }
 ```
@@ -714,9 +696,21 @@ Manages NLT on a host.
 ```
 nimble_linux_toolkit_state: Desired state, absent, present, running or stopped
 nimble_linux_toolkit_bundle: Full path on control node to NLT installer (only required when present or running when not installed)
-nimble_linux_toolkit_options: Additional installer flags (I.e docker or oracle)
+nimble_linux_toolkit_options: Additional installer flags (I.e docker or oracle). In list format.
 nimble_host_protocol: fc or iscsi, optimizes the install procedure for either protocol. Defaults to iscsi.
+nimble_linux_toolkit_nogroup: Do not configure NLT with nltadm --group --add, only relevant when used with legacy Docker or Oracle App Manager. Defaults is True.
+nimble_linux_toolkit_ignore: Defaults to False. Will not under any circumstance try to install NLT. Some tasks won't work but is primarily used for provisioning resources to hosts with manual discovery.
+nimble_static_host_facts: Used with the above parameter to manually populate host facts. See next paragraph.
 ```
+
+If provisioning and mapping resources to a host without using Ansible to discover IQN or WWNPs, the following data structure is needed on the host:
+
+```
+nimble_host_facts:
+  iqn: iqn.1993-08.org.debian:01:1d2529afe63e
+  wwpns: []
+```
+**Note**: World Wide Port Names can be found in `/sys/class/fc_host/host*/port_name` for FC and search for `initiatorname.iscsi` in /etc to find a host IQN when using iSCSI.
 
 ### array setup
 Sets up an array from scratch. The Ansible host needs to be configured with ZeroConf in the same network as the arrays that needs to be setup.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -105,9 +105,9 @@ nimble_host_protocol: iscsi
 # Set to True to disable any NLT interaction
 nimble_linux_toolkit_ignore: False
 
-# Set to True to disable connecting NLT to array
+# Set to False to enable connecting NLT to array
 # Not honored if nimble_linux_toolkit_ignore is True
-nimble_linux_toolkit_nogroup: False
+nimble_linux_toolkit_nogroup: True
 
 # Default initiator options
 nimble_initiator_group_options_default:

--- a/tasks/nimble_volume_attach.yml
+++ b/tasks/nimble_volume_attach.yml
@@ -8,7 +8,7 @@
 
 - name: Host facts
   include: nimble_host_facts.yml
-  when: nimble_host_facts is undefined is undefined
+  when: nimble_host_facts is undefined
 
 - name: Refresh group facts
   include: nimble_group_facts.yml

--- a/tasks/nimble_volume_mount.yml
+++ b/tasks/nimble_volume_mount.yml
@@ -20,38 +20,53 @@
 
 - include: nimble_util_device_name.yml
 
-- name: Ensure device
+- name: Ensure device and paths
   stat:
     path: "{{ nimble_volume_device_name }}"
   register: nimble_volume_device_info
+
 - fail:
     msg: "{{ nimble_volume_device_name }} does not exist."
   when: nimble_volume_device_info.stat.exists == False
 
-- name: Create filesystem label
-  include: util_volume_label.yml
-  vars:
-    util_volume_label: "{{ nimble_volume }}"
+- shell: mountpoint -d "{{ nimble_volume_mountpoint }}" || true
+  register: nimble_volume_mountpoint_mm
 
-- name: Create filesystem
-  filesystem: 
-    dev: "{{ nimble_volume_device_name }}"
-    fstype: xfs
-    opts: -L {{ util_volume_label }} {{ nimble_volume_mkfs_options }}
-  register: nimble_filesystem_created
+- shell: mountpoint -x "{{ nimble_volume_device_name }}" || true
+  register: nimble_volume_device_name_mm
 
-- name: Update label if this is an existing filesystem (clone)
-  shell: xfs_admin -L {{ util_volume_label | quote }} -U {{ ansible_date_time.iso8601_micro | to_uuid }} {{ nimble_volume_device_name | quote }}
-  when: nimble_filesystem_created.changed == False
+- fail:
+    msg: "A different volume is already mounted on the requested mountpoint: {{ nimble_volume_mountpoint }}"
+  when: 
+    - nimble_volume_mountpoint_mm.stdout != nimble_volume_device_name_mm.stdout
+    - nimble_volume_mountpoint_mm.stdout != ""
 
-- name: Mount volume
-  mount:
-    name: "{{ nimble_volume_mountpoint }}"
-    state: mounted
-    src: LABEL={{ util_volume_label }}
-    opts: "{{ nimble_volume_mount_options }},x-systemd.requires={{ nimble_volume_device_name }}"
-    fstype: xfs
-  retries: "{{ nimble_device_retries }}"
-  delay: "{{ nimble_device_delay }}"
-  register: nimble_volume_mounted
-  until: nimble_volume_mounted | success
+- block:
+  - name: Create filesystem label
+    include: util_volume_label.yml
+    vars:
+      util_volume_label: "{{ nimble_volume }}"
+  
+  - name: Create filesystem
+    filesystem: 
+      dev: "{{ nimble_volume_device_name }}"
+      fstype: xfs
+      opts: -L {{ util_volume_label }} {{ nimble_volume_mkfs_options }}
+    register: nimble_filesystem_created
+  
+  - name: Update label if this is an existing filesystem (clone)
+    shell: xfs_admin -L {{ util_volume_label | quote }} -U {{ ansible_date_time.iso8601_micro | to_uuid }} {{ nimble_volume_device_name | quote }}
+    when: nimble_filesystem_created.changed == False
+  
+  - name: Mount volume
+    mount:
+      name: "{{ nimble_volume_mountpoint }}"
+      state: mounted
+      src: LABEL={{ util_volume_label }}
+      opts: "{{ nimble_volume_mount_options }},x-systemd.requires={{ nimble_volume_device_name }}"
+      fstype: xfs
+    retries: "{{ nimble_device_retries }}"
+    delay: "{{ nimble_device_delay }}"
+    register: nimble_volume_mounted
+    until: nimble_volume_mounted | success
+  when: not (nimble_volume_mountpoint_mm.stdout == nimble_volume_device_name_mm.stdout)

--- a/tests/nimble/test.yml
+++ b/tests/nimble/test.yml
@@ -381,6 +381,7 @@
     nimble_volume_size: 30000
     nimble_volume_mountpoint: "/mnt/ansinimble-vol"
   roles:
+    - { role: debug_marker, local_test: "Resize and detach" }
     - { role: NimbleStorage.AnsinimbleTest, nimble_operation: resize, nimble_object: volume } 
     - { role: NimbleStorage.AnsinimbleTest, nimble_operation: umount, nimble_object: volume } 
     - { role: NimbleStorage.AnsinimbleTest, nimble_operation: detach, nimble_object: volume } 
@@ -393,7 +394,7 @@
     nimble_volume_mountpoint: "/mnt/ansinimble-vol"
     nimble_host_name: myhost1
   roles:
-    - { role: debug_marker, local_test: "Resize and delete" }
+    - { role: debug_marker, local_test: "Delete" }
     - { role: NimbleStorage.AnsinimbleTest, nimble_operation: unmap, nimble_object: volume } 
     - { role: NimbleStorage.AnsinimbleTest, nimble_operation: delete, nimble_object: volume } 
     - { role: NimbleStorage.AnsinimbleTest, nimble_operation: delete, nimble_object: folder } 


### PR DESCRIPTION
Closing #35 and defaulting to not bother configure NLT with `nltadm --group --add` unless requested (see README)