### PR TITLE
no-tests-as-filters - Ansible 2.9 compatibility.

### DIFF
--- a/tasks/cloud_lcm_manage.yml
+++ b/tasks/cloud_lcm_manage.yml
@@ -35,7 +35,7 @@
     package: name={{ item }} state=present
     retries: 10
     delay: 30
-    until: result|success
+    until: result is success
     register: result
     with_items: "{{ nimble_host_packages }}"
 

--- a/tasks/cloud_portal_facts.yml
+++ b/tasks/cloud_portal_facts.yml
@@ -18,7 +18,7 @@
   register: cloud_portal_token
   retries: "{{ cloud_uri_retries }}"
   delay: "{{ cloud_uri_delay }}"
-  until: cloud_portal_token | success
+  until: cloud_portal_token is success
 
 - name: Store portal token
   set_fact:
@@ -58,7 +58,7 @@
   no_log: "{{ cloud_silence_payload }}"
   retries: "{{ cloud_uri_retries }}"
   delay: "{{ cloud_uri_delay }}"
-  until: cloud_portal_data | success
+  until: cloud_portal_data is success
 
 - name: Combine portal facts
   set_fact:

--- a/tasks/cloud_replica_clone.yml
+++ b/tasks/cloud_replica_clone.yml
@@ -59,7 +59,7 @@
   register: cloud_replica_snapshots
   retries: "{{ cloud_uri_retries }}"
   delay: "{{ cloud_uri_delay }}"
-  until: cloud_replica_snapshots | success
+  until: cloud_replica_snapshots is success
 
 - set_fact:
     cloud_replica_snapshot_id: "{{ cloud_replica_snapshots.json.data[cloud_replica_snapshot_index].id }}"
@@ -102,4 +102,4 @@
     local_query: "cloud_volumes[?attributes.name=='{{ cloud_replica_options_default.name }}'].attributes.name"
   retries: "{{ cloud_uri_retries }}"
   delay: "{{ cloud_uri_delay }}"
-  until: cloud_volume_created | success
+  until: cloud_volume_created is success

--- a/tasks/cloud_store_create.yml
+++ b/tasks/cloud_store_create.yml
@@ -48,4 +48,4 @@
   retries: "{{ cloud_uri_retries }}"
   delay: "{{ cloud_uri_delay }}"
   register: cloud_store_created
-  until: cloud_store_created | success
+  until: cloud_store_created is success

--- a/tasks/cloud_store_delete.yml
+++ b/tasks/cloud_store_delete.yml
@@ -30,5 +30,5 @@
   retries: "{{ cloud_uri_retries }}"
   delay: "{{ cloud_uri_delay }}"
   register: cloud_store_deleted
-  until: cloud_store_deleted | success
+  until: cloud_store_deleted is success
   when: cloud_store_id

--- a/tasks/cloud_store_resize.yml
+++ b/tasks/cloud_store_resize.yml
@@ -44,4 +44,4 @@
   retries: "{{ cloud_uri_retries }}"
   delay: "{{ cloud_uri_delay }}"
   register: cloud_store_resized
-  until: cloud_store_resized | success
+  until: cloud_store_resized is success

--- a/tasks/cloud_volume_attr.yml
+++ b/tasks/cloud_volume_attr.yml
@@ -16,7 +16,7 @@
     register: cloud_volume_attr_fetch
     retries: "{{ cloud_uri_retries }}"
     delay: "{{ cloud_uri_delay }}"
-    until: cloud_volume_attr_fetch | success
+    until: cloud_volume_attr_fetch is success
 
   - set_fact:
       cloud_volume_attr: "{{ cloud_volume_attr_fetch.json.data.attributes }}"

--- a/tasks/cloud_volume_create.yml
+++ b/tasks/cloud_volume_create.yml
@@ -71,7 +71,7 @@
     register: cloud_volume_snapshots
     retries: "{{ cloud_uri_retries }}"
     delay: "{{ cloud_uri_delay }}"
-    until: cloud_volume_snapshots | success
+    until: cloud_volume_snapshots is success
 
   when: cloud_volume_from is defined
 
@@ -121,7 +121,7 @@
       local_query: "cloud_volumes[?attributes.name=='{{ cloud_volume_options_default.name }}'].attributes.name"
     retries: "{{ cloud_uri_retries }}"
     delay: "{{ cloud_uri_delay }}"
-    until: cloud_volume_created | success
+    until: cloud_volume_created is success
   when: cloud_volume_from is undefined
 
 - block:
@@ -143,5 +143,5 @@
       local_query: "cloud_volumes[?attributes.name=='{{ cloud_volume_from_default.name }}'].attributes.name"
     retries: "{{ cloud_uri_retries }}"
     delay: "{{ cloud_uri_delay }}"
-    until: cloud_volume_created | success
+    until: cloud_volume_created is success
   when: cloud_volume_from is defined

--- a/tasks/cloud_volume_delete.yml
+++ b/tasks/cloud_volume_delete.yml
@@ -31,4 +31,4 @@
   retries: "{{ cloud_uri_retries }}"
   delay: "{{ cloud_uri_delay }}"
   register: cloud_volume_delete
-  until: cloud_volume_delete | success
+  until: cloud_volume_delete is success

--- a/tasks/cloud_volume_map.yml
+++ b/tasks/cloud_volume_map.yml
@@ -39,4 +39,4 @@
   retries: "{{ cloud_uri_retries }}"
   delay: "{{ cloud_uri_delay }}"
   register: cloud_volume_map
-  until: cloud_volume_map | success
+  until: cloud_volume_map is success

--- a/tasks/cloud_volume_mount.yml
+++ b/tasks/cloud_volume_mount.yml
@@ -81,5 +81,5 @@
   retries: "{{ cloud_device_retries }}"
   delay: "{{ cloud_device_delay }}"
   register: cloud_volume_mounted
-  until: cloud_volume_mounted | success
+  until: cloud_volume_mounted is success
   when: cloud_volume_mountpoint_stat.rc != 0

--- a/tasks/cloud_volume_resize.yml
+++ b/tasks/cloud_volume_resize.yml
@@ -45,7 +45,7 @@
   retries: "{{ cloud_uri_retries }}"
   delay: "{{ cloud_uri_delay }}"
   register: cloud_volume_resize
-  until: cloud_volume_resize | success
+  until: cloud_volume_resize is success
 
 - name: Rescan target
   command: iscsiadm -m node -R -T {{ cloud_volume_attr.target_name }}

--- a/tasks/cloud_volume_restore.yml
+++ b/tasks/cloud_volume_restore.yml
@@ -34,7 +34,7 @@
   register: cloud_volume_snapshots
   retries: "{{ cloud_uri_retries }}"
   delay: "{{ cloud_uri_delay }}"
-  until: cloud_volume_snapshots | success
+  until: cloud_volume_snapshots is success
 
 - name: Retrieve snapshot id (named snapshot)
   set_fact:
@@ -71,4 +71,4 @@
   register: cloud_volume_restored
   retries: "{{ cloud_uri_retries }}"
   delay: "{{ cloud_uri_delay }}"
-  until: cloud_volume_restored | success
+  until: cloud_volume_restored is success

--- a/tasks/cloud_volume_snapshot.yml
+++ b/tasks/cloud_volume_snapshot.yml
@@ -38,4 +38,4 @@
   retries: "{{ cloud_uri_retries }}"
   delay: "{{ cloud_uri_delay }}"
   register: cloud_snapshot_created
-  until: cloud_snapshot_created | success
+  until: cloud_snapshot_created is success

--- a/tasks/cloud_volume_unmap.yml
+++ b/tasks/cloud_volume_unmap.yml
@@ -39,4 +39,4 @@
   retries: "{{ cloud_uri_retries }}"
   delay: "{{ cloud_uri_delay }}"
   register: cloud_volume_unmap
-  until: cloud_volume_unmap | success
+  until: cloud_volume_unmap is success

--- a/tasks/cloud_volume_update.yml
+++ b/tasks/cloud_volume_update.yml
@@ -38,7 +38,7 @@
   retries: "{{ cloud_uri_retries }}"
   delay: "{{ cloud_uri_delay }}"
   register: cloud_volume_updated
-  until: cloud_volume_updated | success
+  until: cloud_volume_updated is success
 
 - name: Refresh volumes
   include: cloud_portal_facts.yml

--- a/tasks/nimble_cloud_divorce.yml
+++ b/tasks/nimble_cloud_divorce.yml
@@ -43,7 +43,7 @@
       retries: "{{ nimble_uri_retries }}"
       delay: "{{ nimble_uri_delay }}"
       register: nimble_partner_deleted
-      until: nimble_partner_deleted | success
+      until: nimble_partner_deleted is success
 
     - uri:
         url: "{{ cloud_portal_api_endpoint }}/replication_partnerships/{{ cloud_partnership_data.id }}"
@@ -57,7 +57,7 @@
       retries: "{{ cloud_uri_retries }}"
       delay: "{{ cloud_uri_delay }}"
       register: cloud_partnership_deleted
-      until: cloud_partnership_deleted | success
+      until: cloud_partnership_deleted is success
 
     - uri:
         url: "{{ cloud_portal_api_endpoint }}/onprem_replication_partners/{{ cloud_partnership_data.partner_id }}"
@@ -71,5 +71,5 @@
       retries: "{{ cloud_uri_retries }}"
       delay: "{{ cloud_uri_delay }}"
       register: cloud_onprem_partner_deleted
-      until: cloud_onprem_partner_deleted | success
+      until: cloud_onprem_partner_deleted is success
   when: cloud_partnership_data or nimble_partner_id

--- a/tasks/nimble_cloud_partner.yml
+++ b/tasks/nimble_cloud_partner.yml
@@ -28,7 +28,7 @@
 - name: Ensure compatibility
   fail:
     msg: "Need NimbleOS >= 4.5"
-  when: nimble_group_version | version_compare('4.5', '<')
+  when: nimble_group_version is version_compare('4.5', '<')
 
 - name: Merge options
   set_fact:
@@ -74,7 +74,7 @@
       retries: "{{ cloud_uri_retries }}"
       delay: "{{ cloud_uri_delay }}"
       register: cloud_store_created
-      until: cloud_store_created | success
+      until: cloud_store_created is success
   when: not cloud_store_query
 
 - name: Create Replication Partner
@@ -98,7 +98,7 @@
   retries: "{{ cloud_uri_retries }}"
   delay: "{{ cloud_uri_delay }}"
   register: cloud_onprem_partner_created
-  until: cloud_onprem_partner_created | success
+  until: cloud_onprem_partner_created is success
 
 - name: Create Replication Partnership
   set_fact:
@@ -123,7 +123,7 @@
   retries: "{{ cloud_uri_retries }}"
   delay: "{{ cloud_uri_delay }}"
   register: cloud_repl_partnership_created
-  until: cloud_repl_partnership_created | success
+  until: cloud_repl_partnership_created is success
 
 - name: Create Local Partner
   set_fact:
@@ -155,7 +155,7 @@
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
   register: nimble_cloud_partner_created
-  until: nimble_cloud_partner_created | success
+  until: nimble_cloud_partner_created is success
 
 - name: Test partnership
   uri:
@@ -170,4 +170,4 @@
   retries: "{{ nimble_uri_retries * 3 }}"
   delay: "{{ nimble_uri_delay * 3 }}"
   register: nimble_partner_tested
-  until: nimble_partner_tested | success
+  until: nimble_partner_tested is success

--- a/tasks/nimble_folder_create.yml
+++ b/tasks/nimble_folder_create.yml
@@ -39,4 +39,4 @@
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
   register: nimble_folder_created
-  until: nimble_folder_created | success
+  until: nimble_folder_created is success

--- a/tasks/nimble_folder_delete.yml
+++ b/tasks/nimble_folder_delete.yml
@@ -26,4 +26,4 @@
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
   register: nimble_folder_deleted
-  until: nimble_folder_deleted | success
+  until: nimble_folder_deleted is success

--- a/tasks/nimble_folder_update.yml
+++ b/tasks/nimble_folder_update.yml
@@ -35,4 +35,4 @@
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
   register: nimble_folder_updated
-  until: nimble_folder_updated | success
+  until: nimble_folder_updated is success

--- a/tasks/nimble_group_facts.yml
+++ b/tasks/nimble_group_facts.yml
@@ -16,7 +16,7 @@
     register: nimble_group_token
     retries: "{{ nimble_uri_retries }}"
     delay: "{{ nimble_uri_delay }}"
-    until: nimble_group_token | success
+    until: nimble_group_token is success
 
   - name: Store group token
     set_fact:
@@ -62,7 +62,7 @@
     no_log: "{{ nimble_silence_payload }}"
     retries: "{{ nimble_uri_retries }}"
     delay: "{{ nimble_uri_delay }}"
-    until: nimble_group_data | success
+    until: nimble_group_data is success
 
   - name: Combine group facts
     set_fact:

--- a/tasks/nimble_group_update.yml
+++ b/tasks/nimble_group_update.yml
@@ -27,4 +27,4 @@
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
   register: nimble_group_updated
-  until: nimble_group_updated | success
+  until: nimble_group_updated is success

--- a/tasks/nimble_nlt_manage.yml
+++ b/tasks/nimble_nlt_manage.yml
@@ -59,7 +59,7 @@
       state: present
     retries: 10
     delay: 30
-    until: result|success
+    until: result is success
     register: result
     with_items: "{{ nimble_host_packages[nimble_host_protocol] }}"
 

--- a/tasks/nimble_password_update.yml
+++ b/tasks/nimble_password_update.yml
@@ -38,4 +38,4 @@
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
   register: nimble_password_changed
-  until: nimble_password_changed | success
+  until: nimble_password_changed is success

--- a/tasks/nimble_perfpolicy_create.yml
+++ b/tasks/nimble_perfpolicy_create.yml
@@ -36,4 +36,4 @@
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
   register: nimble_perfpolicy_created
-  until: nimble_perfpolicy_created | success
+  until: nimble_perfpolicy_created is success

--- a/tasks/nimble_perfpolicy_delete.yml
+++ b/tasks/nimble_perfpolicy_delete.yml
@@ -34,4 +34,4 @@
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
   register: nimble_perfpolicy_deleted
-  until: nimble_perfpolicy_deleted | success
+  until: nimble_perfpolicy_deleted is success

--- a/tasks/nimble_perfpolicy_update.yml
+++ b/tasks/nimble_perfpolicy_update.yml
@@ -38,4 +38,4 @@
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
   register: nimble_perfpolicy_updated
-  until: nimble_perfpolicy_updated | success
+  until: nimble_perfpolicy_updated is success

--- a/tasks/nimble_prottmpl_create.yml
+++ b/tasks/nimble_prottmpl_create.yml
@@ -38,7 +38,7 @@
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
   register: nimble_prottmpl_created
-  until: nimble_prottmpl_created | success
+  until: nimble_prottmpl_created is success
 
 - block:
   - name: Process schedules

--- a/tasks/nimble_prottmpl_delete.yml
+++ b/tasks/nimble_prottmpl_delete.yml
@@ -24,4 +24,4 @@
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
   register: nimble_prottmpl_deleted
-  until: nimble_prottmpl_deleted | success
+  until: nimble_prottmpl_deleted is success

--- a/tasks/nimble_replication_divorce.yml
+++ b/tasks/nimble_replication_divorce.yml
@@ -33,5 +33,5 @@
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay * 3 }}"
   register: nimble_partner_deleted
-  until: nimble_partner_deleted | success
+  until: nimble_partner_deleted is success
   when: nimble_partner_id | string

--- a/tasks/nimble_snapshot_delete.yml
+++ b/tasks/nimble_snapshot_delete.yml
@@ -31,6 +31,6 @@
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
   register: nimble_snapshot_deleted
-  until: nimble_snapshot_deleted | success
+  until: nimble_snapshot_deleted is success
   changed_when: nimble_snapshot_deleted.status == 200
   when: nimble_snapshot_id != ""

--- a/tasks/nimble_snapshot_update.yml
+++ b/tasks/nimble_snapshot_update.yml
@@ -46,5 +46,5 @@
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
   register: nimble_snapshot_updated
-  until: nimble_snapshot_updated | success
+  until: nimble_snapshot_updated is success
   when: nimble_snapshot_update_options_default != {}

--- a/tasks/nimble_util_add_schedule.yml
+++ b/tasks/nimble_util_add_schedule.yml
@@ -41,4 +41,4 @@
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
   register: nimble_protsched_created
-  until: nimble_protsched_created | success
+  until: nimble_protsched_created is success

--- a/tasks/nimble_util_replication_partnership.yml
+++ b/tasks/nimble_util_replication_partnership.yml
@@ -50,7 +50,7 @@
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
   register: nimble_partner_created
-  until: nimble_partner_created | success
+  until: nimble_partner_created is success
   when: not nimble_partner_id | string
 
 - name: Test partnership
@@ -66,5 +66,5 @@
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
   register: nimble_partner_tested
-  until: nimble_partner_tested | success
+  until: nimble_partner_tested is success
   when: nimble_partner_id | string

--- a/tasks/nimble_volcoll_create.yml
+++ b/tasks/nimble_volcoll_create.yml
@@ -42,4 +42,4 @@
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
   register: nimble_volcoll_created
-  until: nimble_volcoll_created | success
+  until: nimble_volcoll_created is success

--- a/tasks/nimble_volcoll_prune.yml
+++ b/tasks/nimble_volcoll_prune.yml
@@ -17,5 +17,5 @@
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
   register: nimble_volcoll_deleted
-  until: nimble_volcoll_deleted | success
+  until: nimble_volcoll_deleted is success
   with_items: "{{ nimble_group_facts.volume_collections }}"

--- a/tasks/nimble_volcoll_snapshot.yml
+++ b/tasks/nimble_volcoll_snapshot.yml
@@ -52,7 +52,7 @@
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
   register: nimble_snapshots_created
-  until: nimble_snapshots_created | success
+  until: nimble_snapshots_created is success
   vars:
     local_query: "snapshot_collections[?name=='{{ nimble_volcoll_snapshot }}'].name | [0]"
   when: nimble_group_facts | json_query(local_query) != nimble_volcoll_snapshot

--- a/tasks/nimble_volume_create.yml
+++ b/tasks/nimble_volume_create.yml
@@ -13,12 +13,12 @@
 - name: Figure out volume query (NimbleOS >=4)
   set_fact:
     nimble_volume_query: "fields=name,id,last_snap"
-  when: nimble_group_version | version_compare('4', '>=')
+  when: nimble_group_version is version_compare('4', '>=')
 
 - name: Figure out volume query (NimbleOS < 4)
   set_fact:
     nimble_volume_query: "fields=name,id"
-  when: nimble_group_version | version_compare('4', '<')
+  when: nimble_group_version is version_compare('4', '<')
 
 - name: Refresh group facts
   include: nimble_group_facts.yml
@@ -59,7 +59,7 @@
     register: nimble_volume_snapshots
     retries: "{{ nimble_uri_retries }}"
     delay: "{{ nimble_uri_delay }}"
-    until: nimble_volume_snapshots | success
+    until: nimble_volume_snapshots is success
 
   - name: Retrieve snapshot id
     set_fact:
@@ -75,7 +75,7 @@
     nimble_volume_snapshot_id: "{{ nimble_group_facts | json_query(local_query) }}"
   vars:
     local_query: "volumes[?name=='{{ nimble_volume_from }}'].last_snap.snap_id | [0]"
-  when: nimble_volume_snapshot is undefined and nimble_volume_from is defined and nimble_group_version | version_compare('4', '>=')
+  when: nimble_volume_snapshot is undefined and nimble_volume_from is defined and nimble_group_version is version_compare('4', '>=')
 
 - block:
   - name: Get nimble_volume_id (NimbleOS < 4)
@@ -96,7 +96,7 @@
     register: nimble_volume_snapshots
     retries: "{{ nimble_uri_retries }}"
     delay: "{{ nimble_uri_delay }}"
-    until: nimble_volume_snapshots | success
+    until: nimble_volume_snapshots is success
 
   - name: Retrieve snapshot id (NimbleOS < 4)
     set_fact:
@@ -104,7 +104,7 @@
     vars:
       local_query: "data[?vol_id=='{{ nimble_volume_id }}'].id | [0]"
 
-  when: nimble_volume_snapshot is undefined and nimble_volume_from is defined and nimble_group_version | version_compare('4', '<')
+  when: nimble_volume_snapshot is undefined and nimble_volume_from is defined and nimble_group_version is version_compare('4', '<')
 
 - block:
   - name: Ensure a snapshot name
@@ -187,5 +187,5 @@
     local_query: "volumes[?name=='{{ nimble_volume_options_default.name }}'].name"
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
-  until: nimble_volume_created | success
+  until: nimble_volume_created is success
   changed_when: nimble_volume_created.status == 201

--- a/tasks/nimble_volume_delete.yml
+++ b/tasks/nimble_volume_delete.yml
@@ -34,7 +34,7 @@
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
   register: nimble_volume_deleteprep
-  until: nimble_volume_deleteprep | success
+  until: nimble_volume_deleteprep is success
   changed_when:
   - nimble_volume_deleteprep.status == 200
   when:
@@ -51,6 +51,6 @@
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
   register: nimble_volume_deleted
-  until: nimble_volume_deleted | success
+  until: nimble_volume_deleted is success
   when: nimble_volume_deleteprep.changed
   changed_when: nimble_volume_deleted.status == 200

--- a/tasks/nimble_volume_map.yml
+++ b/tasks/nimble_volume_map.yml
@@ -61,7 +61,7 @@
     local_query: "initiator_groups[?name=='{{ nimble_initiator_group_options_default.name }}'].name"
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
-  until: nimble_initiator_group | success
+  until: nimble_initiator_group is success
 
 - name: Merge nimble_initiator_options
   set_fact:
@@ -106,7 +106,7 @@
     retries: "{{ nimble_uri_retries }}"
     delay: "{{ nimble_uri_delay }}"
     register: nimble_initiator_created
-    until: nimble_initiator_created | success
+    until: nimble_initiator_created is success
   when: nimble_host_protocol == 'iscsi' and nimble_initiator_group_id is defined
 
 - block:
@@ -128,7 +128,7 @@
     retries: "{{ nimble_uri_retries }}"
     delay: "{{ nimble_uri_delay }}"
     register: nimble_initiator_created
-    until: nimble_initiator_created | success
+    until: nimble_initiator_created is success
     with_items: "{{ nimble_host_facts.wwpns }}"
     when: nimble_group_facts | json_query(local_query) == []
     vars:
@@ -157,7 +157,7 @@
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
   register: nimble_volume_onlined
-  until: nimble_volume_onlined | success
+  until: nimble_volume_onlined is success
 
 - name: Create Access Control Record
   uri:
@@ -179,4 +179,4 @@
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
   register: nimble_acr_created
-  until: nimble_acr_created | success
+  until: nimble_acr_created is success

--- a/tasks/nimble_volume_mount.yml
+++ b/tasks/nimble_volume_mount.yml
@@ -70,5 +70,5 @@
     retries: "{{ nimble_device_retries }}"
     delay: "{{ nimble_device_delay }}"
     register: nimble_volume_mounted
-    until: nimble_volume_mounted | success
+    until: nimble_volume_mounted is success
   when: not (nimble_volume_mountpoint_mm.stdout == nimble_volume_device_name_mm.stdout)

--- a/tasks/nimble_volume_protect.yml
+++ b/tasks/nimble_volume_protect.yml
@@ -53,7 +53,7 @@
     register: local_volume_protect
     retries: "{{ nimble_uri_retries }}"
     delay: "{{ nimble_uri_delay }}"
-    until: local_volume_protect | success
+    until: local_volume_protect is success
   when: nimble_volcoll is defined
 
 - block:
@@ -87,7 +87,7 @@
     retries: "{{ nimble_uri_retries }}"
     delay: "{{ nimble_uri_delay }}"
     register: nimble_volcoll_created
-    until: nimble_volcoll_created | success
+    until: nimble_volcoll_created is success
 
   - name: Assign volcoll
     uri:
@@ -105,5 +105,5 @@
     register: local_volume_protect
     retries: "{{ nimble_uri_retries }}"
     delay: "{{ nimble_uri_delay }}"
-    until: local_volume_protect | success
+    until: local_volume_protect is success
   when: nimble_protection_template is defined

--- a/tasks/nimble_volume_resize.yml
+++ b/tasks/nimble_volume_resize.yml
@@ -32,7 +32,7 @@
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
   register: nimble_volume_resized
-  until: nimble_volume_resized | success
+  until: nimble_volume_resized is success
   delegate_to: 127.0.0.1
   delegate_facts: False
   connection: local

--- a/tasks/nimble_volume_restore.yml
+++ b/tasks/nimble_volume_restore.yml
@@ -12,12 +12,12 @@
 - name: Figure out volume query (NimbleOS >=4)
   set_fact:
     nimble_volume_fields: "fields=name,id,last_snap&name={{ nimble_volume }}"
-  when: nimble_group_version | version_compare('4', '>=')
+  when: nimble_group_version is version_compare('4', '>=')
 
 - name: Figure out volume query (NimbleOS < 4)
   set_fact:
     nimble_volume_fields: "fields=name,id&name={{ nimble_volume }}"
-  when: nimble_group_version | version_compare('4', '<')
+  when: nimble_group_version is version_compare('4', '<')
 
 - name: Refresh group facts
   include: nimble_group_facts.yml
@@ -36,7 +36,7 @@
     nimble_volume_snapshot_id: "{{ nimble_group_facts | json_query(local_query) }}"
   vars:
     local_query: "volumes[?name=='{{ nimble_volume }}'].last_snap.snap_id | [0]"
-  when: nimble_volume_snapshot is undefined and nimble_group_version | version_compare('4', '>=')
+  when: nimble_volume_snapshot is undefined and nimble_group_version is version_compare('4', '>=')
 
 - block:
   - name: Query for snapshots on nimble_volume
@@ -51,7 +51,7 @@
     register: nimble_volume_snapshots
     retries: "{{ nimble_uri_retries }}"
     delay: "{{ nimble_uri_delay }}"
-    until: nimble_volume_snapshots | success
+    until: nimble_volume_snapshots is success
 
   - name: Retrieve snapshot ID
     set_fact:
@@ -65,9 +65,9 @@
       nimble_volume_snapshot_id: "{{ nimble_volume_snapshots.json | json_query(local_query) }}"
     vars:
       local_query: "data[?vol_id=='{{ nimble_volume_id }}'].id | [0]"
-    when: nimble_volume_snapshot is undefined and nimble_group_version | version_compare('4', '<')
+    when: nimble_volume_snapshot is undefined and nimble_group_version is version_compare('4', '<')
 
-  when: nimble_volume_snapshot is defined or nimble_group_version | version_compare('4', '<')
+  when: nimble_volume_snapshot is defined or nimble_group_version is version_compare('4', '<')
   delegate_to: 127.0.0.1
   delegate_facts: False
   connection: local
@@ -88,7 +88,7 @@
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
   register: nimble_volume_restored
-  until: nimble_volume_restored | success
+  until: nimble_volume_restored is success
   delegate_to: 127.0.0.1
   delegate_facts: False
   connection: local

--- a/tasks/nimble_volume_snapshot.yml
+++ b/tasks/nimble_volume_snapshot.yml
@@ -36,7 +36,7 @@
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
   register: nimble_snapshot_created
-  until: nimble_snapshot_created | success
+  until: nimble_snapshot_created is success
 
 - name: Refresh volumes
   include: nimble_group_facts.yml

--- a/tasks/nimble_volume_unmap.yml
+++ b/tasks/nimble_volume_unmap.yml
@@ -33,7 +33,7 @@
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
   register: nimble_acr_deleted
-  until: nimble_acr_deleted | success
+  until: nimble_acr_deleted is success
 
 - include: nimble_util_volume_id.yml
 
@@ -53,7 +53,7 @@
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
   register: nimble_volume_offline
-  until: nimble_volume_offline | success
+  until: nimble_volume_offline is success
 
 - name: Refresh initiator_groups
   include: nimble_group_facts.yml
@@ -83,4 +83,4 @@
     local_query: "initiator_groups[?id=='{{ nimble_initiator_group_id }}'].{v: volume_count, id: id}[?v==`0`]|[0].id"
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
-  until: nimble_initiator_group_deleted | success
+  until: nimble_initiator_group_deleted is success

--- a/tasks/nimble_volume_unprotect.yml
+++ b/tasks/nimble_volume_unprotect.yml
@@ -30,4 +30,4 @@
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
   register: nimble_volcoll_updated
-  until: nimble_volcoll_updated | success
+  until: nimble_volcoll_updated is success

--- a/tasks/nimble_volume_update.yml
+++ b/tasks/nimble_volume_update.yml
@@ -38,5 +38,5 @@
   retries: "{{ nimble_uri_retries }}"
   delay: "{{ nimble_uri_delay }}"
   register: nimble_volume_updated
-  until: nimble_volume_updated | success
+  until: nimble_volume_updated is success
   when: nimble_volume_update_options_default != {}


### PR DESCRIPTION
Using Ansible provided Jinja2 tests as filters will be removed in Ansible 2.9.
https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/no-tests-as-filters.html